### PR TITLE
Fixed crash when selected while no entities configured

### DIFF
--- a/widget/source/Entities/EntityListView.mc
+++ b/widget/source/Entities/EntityListView.mc
@@ -72,6 +72,9 @@ class EntityListDelegate extends Ui.BehaviorDelegate {
 
   function onSelect() {
     var entity = _mController.getCurrentEntity();
+    if (entity == null) {
+        return false;
+    }
     _mController.toggleEntity(entity);
 
     return true;


### PR DESCRIPTION
When there are no loaded entities (console prints `Loaded entities: []`) and user triggers selection on **No entities configured** screen the app crashes. Simple `if` solves this problem.